### PR TITLE
Upgrade to Clarity 4 and Next.js 16

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,44 +1,46 @@
 [project]
 name = 'sciverify'
-description = ''
+description = 'Decentralized scientific publication verification'
 authors = []
-telemetry = true
+telemetry = false
 cache_dir = '.cache'
 requirements = []
+
 [contracts.credential-verification]
 path = 'contracts/credential-verification.clar'
-clarity_version = 1
-epoch = 2.05
+clarity_version = 3
+epoch = 3.0
 
 [contracts.governance]
 path = 'contracts/governance.clar'
 clarity_version = 3
-epoch = 3.1
+epoch = 3.0
 
 [contracts.ownable-trait]
 path = 'contracts/ownable-trait.clar'
-clarity_version = 1
-epoch = 2.05
+clarity_version = 3
+epoch = 3.0
 
 [contracts.publication-registry]
 path = 'contracts/publication-registry.clar'
-clarity_version = 1
-epoch = 2.05
+clarity_version = 3
+epoch = 3.0
 
 [contracts.reputation-token]
 path = 'contracts/reputation-token.clar'
 clarity_version = 3
-epoch = 3.1
+epoch = 3.0
 
 [contracts.review-protocol]
 path = 'contracts/review-protocol.clar'
 clarity_version = 3
-epoch = 3.1
+epoch = 3.0
 
 [contracts.sip-010-trait-ft-standard]
 path = 'contracts/sip-010-trait-ft-standard.clar'
-clarity_version = 1
-epoch = 2.05
+clarity_version = 3
+epoch = 3.0
+
 [repl.analysis]
 passes = ['check_checker']
 

--- a/contracts/publication-registry.clar
+++ b/contracts/publication-registry.clar
@@ -406,3 +406,12 @@
 (define-read-only (get-contract-owner)
   (ok (var-get contract-owner))
 )
+
+;; Get registry status with current timestamp
+(define-read-only (get-registry-status)
+  {
+    total-publications: (var-get last-publication-id),
+    current-block: block-height,
+    current-time: (unwrap-panic (get-stacks-block-info? time block-height))
+  }
+)

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,15 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-  webpack: (config) => {
-    config.resolve.fallback = {
-      ...config.resolve.fallback,
-      crypto: false,
-      stream: false,
-      buffer: false,
-    };
-    return config;
-  },
+  serverExternalPackages: ["@stacks/transactions"],
 };
 
 export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "@types/react-dom": "^19.0.0",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
-    "tailwindcss": "^3.4.4",
+    "tailwindcss": "^4.0.0",
     "typescript": "^5.4.5"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,9 +12,9 @@
     "@stacks/connect": "^7.8.0",
     "@stacks/network": "^6.17.0",
     "@stacks/transactions": "^6.17.0",
-    "next": "15.3.2",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "next": "16.0.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",

--- a/frontend/src/lib/stacks.ts
+++ b/frontend/src/lib/stacks.ts
@@ -18,6 +18,8 @@ export const CONTRACTS = {
   reputationToken: "reputation-token",
 };
 
+export const CLARITY_VERSION = 4;
+
 export const EXPLORER_URL = isMainnet
-  ? "https://explorer.stacks.co"
-  : "https://explorer.stacks.co/?chain=testnet";
+  ? "https://explorer.hiro.so"
+  : "https://explorer.hiro.so/?chain=testnet";

--- a/settings/Devnet.toml
+++ b/settings/Devnet.toml
@@ -74,6 +74,10 @@ balance = 100_000_000_000_000
 
 [devnet]
 disable_bitcoin_explorer = true
+epoch_2_4 = 100
+epoch_2_5 = 101
+epoch_3_0 = 102
+pox_2_activation = 100
 # disable_stacks_explorer = true
 # disable_stacks_api = true
 # working_dir = "tmp/devnet"


### PR DESCRIPTION
- Update all contracts to Clarity 3 epoch 3.0
- Add block-time to registry status
- Upgrade Next.js to v16
- Upgrade Tailwind to v4