### PR TITLE
Add on-chain governance proposal voting

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -774,3 +774,48 @@ body {
   color: #b91c1c;
   border-color: #fecaca;
 }
+
+/* Governance styles */
+.proposal-card {
+  border-left: 4px solid #6366f1;
+}
+
+.vote-bar-for {
+  background: #16a34a;
+}
+
+.vote-bar-against {
+  background: #dc2626;
+}
+
+.quorum-line {
+  border-left: 2px dashed #6b7280;
+}
+
+.governance-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+@media (max-width: 640px) {
+  .governance-stats {
+    grid-template-columns: 1fr;
+  }
+}
+
+.proposal-card:hover {
+  border-left-color: #4f46e5;
+}
+
+.vote-weight-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 9999px;
+  background: #ede9fe;
+  color: #5b21b6;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.125rem 0.625rem;
+}

--- a/frontend/src/app/governance/[id]/page.tsx
+++ b/frontend/src/app/governance/[id]/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { use, useMemo } from 'react';
+import { use } from 'react';
 import { useFetchProposals } from '@/hooks/useFetchProposals';
+import { useFetchVotes } from '@/hooks/useFetchVotes';
 import { useVote } from '@/hooks/useVote';
 import { useWallet } from '@/hooks/useWallet';
 import VoteButtons from '@/components/VoteButtons';
@@ -9,15 +10,8 @@ import VoteProgressBar from '@/components/VoteProgressBar';
 import QuorumIndicator from '@/components/QuorumIndicator';
 import ProposalStatusBadge from '@/components/ProposalStatusBadge';
 import VoteHistoryList from '@/components/VoteHistoryList';
+import ProposalTimeline from '@/components/ProposalTimeline';
 import { canVote, formatBlocksRemaining, getVoteResult } from '@/lib/governanceUtils';
-import { Vote } from '@/types/governance';
-
-// Sample vote history — replace with contract reads
-const MOCK_VOTES: Vote[] = [
-  { proposalId: 1, voter: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM', support: true, weight: 2500, txHash: '0xabc', timestamp: 1743600000000 },
-  { proposalId: 1, voter: 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG', support: false, weight: 1800, txHash: '0xdef', timestamp: 1743650000000 },
-  { proposalId: 1, voter: 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5NH7C3C56', support: true, weight: 3100, txHash: '0xghi', timestamp: 1743700000000 },
-];
 
 const CURRENT_BLOCK = 147000;
 
@@ -29,16 +23,14 @@ export default function ProposalDetailPage({ params }: PageProps) {
   const { id } = use(params);
   const proposalId = Number(id);
   const { proposals, loading } = useFetchProposals();
+  const { votes, loading: votesLoading } = useFetchVotes(proposalId);
   const { isConnected, getAddress } = useWallet();
 
   const proposal = proposals.find((p) => p.id === proposalId);
   const address = getAddress();
   const { vote, voting, error: voteError, txId, hasVoted, voteWeight } = useVote(proposalId, address ?? null);
 
-  const proposalVotes = useMemo(
-    () => MOCK_VOTES.filter((v) => v.proposalId === proposalId),
-    [proposalId]
-  );
+  const proposalVotes = votes;
 
   if (loading) {
     return (
@@ -131,8 +123,16 @@ export default function ProposalDetailPage({ params }: PageProps) {
         </div>
       )}
 
+      <div className="mb-6">
+        <ProposalTimeline proposal={proposal} currentBlock={CURRENT_BLOCK} />
+      </div>
+
       <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-        <VoteHistoryList votes={proposalVotes} />
+        {votesLoading ? (
+          <div className="h-20 animate-pulse rounded bg-gray-50" />
+        ) : (
+          <VoteHistoryList votes={proposalVotes} />
+        )}
       </div>
     </main>
   );

--- a/frontend/src/app/governance/[id]/page.tsx
+++ b/frontend/src/app/governance/[id]/page.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { use, useMemo } from 'react';
+import { useFetchProposals } from '@/hooks/useFetchProposals';
+import { useVote } from '@/hooks/useVote';
+import { useWallet } from '@/hooks/useWallet';
+import VoteButtons from '@/components/VoteButtons';
+import VoteProgressBar from '@/components/VoteProgressBar';
+import QuorumIndicator from '@/components/QuorumIndicator';
+import ProposalStatusBadge from '@/components/ProposalStatusBadge';
+import VoteHistoryList from '@/components/VoteHistoryList';
+import { canVote, formatBlocksRemaining, getVoteResult } from '@/lib/governanceUtils';
+import { Vote } from '@/types/governance';
+
+// Sample vote history — replace with contract reads
+const MOCK_VOTES: Vote[] = [
+  { proposalId: 1, voter: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM', support: true, weight: 2500, txHash: '0xabc', timestamp: 1743600000000 },
+  { proposalId: 1, voter: 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG', support: false, weight: 1800, txHash: '0xdef', timestamp: 1743650000000 },
+  { proposalId: 1, voter: 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5NH7C3C56', support: true, weight: 3100, txHash: '0xghi', timestamp: 1743700000000 },
+];
+
+const CURRENT_BLOCK = 147000;
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default function ProposalDetailPage({ params }: PageProps) {
+  const { id } = use(params);
+  const proposalId = Number(id);
+  const { proposals, loading } = useFetchProposals();
+  const { isConnected, getAddress } = useWallet();
+
+  const proposal = proposals.find((p) => p.id === proposalId);
+  const address = getAddress();
+  const { vote, voting, error: voteError, txId, hasVoted, voteWeight } = useVote(proposalId, address ?? null);
+
+  const proposalVotes = useMemo(
+    () => MOCK_VOTES.filter((v) => v.proposalId === proposalId),
+    [proposalId]
+  );
+
+  if (loading) {
+    return (
+      <main className="mx-auto max-w-4xl px-4 py-10">
+        <div className="space-y-4">
+          <div className="h-8 animate-pulse rounded bg-gray-100 w-2/3" />
+          <div className="h-32 animate-pulse rounded-xl bg-gray-100" />
+        </div>
+      </main>
+    );
+  }
+
+  if (!proposal) {
+    return (
+      <main className="mx-auto max-w-4xl px-4 py-10 text-center">
+        <p className="text-gray-500">Proposal #{id} not found.</p>
+        <a href="/governance" className="mt-3 block text-sm text-accent-600 hover:text-accent-700">
+          ← Back to Governance
+        </a>
+      </main>
+    );
+  }
+
+  const votable = canVote(proposal, CURRENT_BLOCK);
+  const result = getVoteResult(proposal);
+  const timeLeft = formatBlocksRemaining(proposal.endBlock, CURRENT_BLOCK);
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-10 sm:px-6 lg:px-8">
+      <a href="/governance" className="mb-6 block text-sm text-gray-500 hover:text-gray-700">
+        ← Back to Governance
+      </a>
+
+      <div className="mb-6 flex flex-wrap items-start gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-2 flex-wrap">
+            <span className="text-xs text-gray-400 font-mono">#{proposal.id}</span>
+            <ProposalStatusBadge status={proposal.status} />
+            {result !== 'pending' && (
+              <span className={`text-xs font-semibold capitalize ${result === 'passing' ? 'text-green-600' : 'text-red-600'}`}>
+                {result}
+              </span>
+            )}
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900">{proposal.title}</h1>
+          <p className="mt-1 text-xs text-gray-400">
+            Proposed by <span className="font-mono">{proposal.proposer.slice(0, 8)}...</span>
+            {proposal.status === 'active' && <span className="ml-2">{timeLeft}</span>}
+          </p>
+        </div>
+        <QuorumIndicator
+          votes={proposal.votesFor + proposal.votesAgainst}
+          quorum={proposal.quorumRequired}
+        />
+      </div>
+
+      <div className="mb-6 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-2 text-sm font-semibold text-gray-700">Description</h2>
+        <p className="text-sm leading-relaxed text-gray-600">{proposal.description}</p>
+      </div>
+
+      <div className="mb-6 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-4 text-sm font-semibold text-gray-700">Vote Distribution</h2>
+        <VoteProgressBar
+          votesFor={proposal.votesFor}
+          votesAgainst={proposal.votesAgainst}
+          quorum={proposal.quorumRequired}
+        />
+      </div>
+
+      {isConnected && votable && (
+        <div className="mb-6 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+          <h2 className="mb-4 text-sm font-semibold text-gray-700">Cast Your Vote</h2>
+          {voteError && <p className="mb-3 text-sm text-red-600">{voteError}</p>}
+          {txId && (
+            <p className="mb-3 text-sm text-green-600 font-medium">
+              Vote submitted!{' '}
+              <a href={`https://explorer.stacks.co/txid/${txId}`} target="_blank" rel="noopener noreferrer" className="underline">
+                View tx →
+              </a>
+            </p>
+          )}
+          <VoteButtons
+            proposalId={proposal.id}
+            onVote={vote}
+            hasVoted={hasVoted}
+            voting={voting}
+            voteWeight={voteWeight}
+          />
+        </div>
+      )}
+
+      <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <VoteHistoryList votes={proposalVotes} />
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/governance/new/page.tsx
+++ b/frontend/src/app/governance/new/page.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import ProposalForm from '@/components/ProposalForm';
+import { useWallet } from '@/hooks/useWallet';
+
+export default function NewProposalPage() {
+  const { isConnected } = useWallet();
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-10 sm:px-6 lg:px-8">
+      <a href="/governance" className="mb-6 block text-sm text-gray-500 hover:text-gray-700">
+        ← Back to Governance
+      </a>
+
+      <h1 className="mb-2 text-2xl font-bold text-gray-900">Create Proposal</h1>
+      <p className="mb-8 text-sm text-gray-500">
+        Submit a governance proposal for the SciVerify community to vote on. Your proposal will be
+        active for voting once confirmed on chain.
+      </p>
+
+      {!isConnected ? (
+        <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 py-14 text-center">
+          <p className="text-sm text-gray-500">Connect your Stacks wallet to create a proposal.</p>
+        </div>
+      ) : (
+        <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <ProposalForm
+            onSuccess={(txId) => {
+              console.info('Proposal tx:', txId);
+            }}
+          />
+        </div>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/app/governance/page.tsx
+++ b/frontend/src/app/governance/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useFetchProposals } from '@/hooks/useFetchProposals';
+import ProposalCard from '@/components/ProposalCard';
+import GovernanceStats from '@/components/GovernanceStats';
+
+export default function GovernancePage() {
+  const { proposals, loading, error, refetch } = useFetchProposals();
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mb-8 flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Governance</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Vote on proposals that shape the SciVerify protocol.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={refetch}
+            className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 transition"
+          >
+            Refresh
+          </button>
+          <a
+            href="/governance/new"
+            className="rounded-lg bg-accent-600 px-3 py-2 text-xs font-medium text-white shadow-sm hover:bg-accent-700 transition"
+          >
+            New Proposal
+          </a>
+        </div>
+      </div>
+
+      {!loading && !error && (
+        <div className="mb-8">
+          <GovernanceStats proposals={proposals} />
+        </div>
+      )}
+
+      {loading && (
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-40 animate-pulse rounded-xl bg-gray-100" />
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-600">
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && proposals.length === 0 && (
+        <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 py-16 text-center">
+          <p className="text-sm text-gray-500">No proposals yet. Create the first one!</p>
+        </div>
+      )}
+
+      {!loading && !error && proposals.length > 0 && (
+        <div className="space-y-4">
+          {proposals.map((proposal) => (
+            <ProposalCard key={proposal.id} proposal={proposal} />
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/components/GovernanceStats.tsx
+++ b/frontend/src/components/GovernanceStats.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { Proposal, Vote } from '@/types/governance';
+import { computeParticipationRate } from '@/lib/governanceUtils';
+
+interface GovernanceStatsProps {
+  proposals: Proposal[];
+  votes?: Vote[];
+  eligibleCount?: number;
+}
+
+interface StatCardProps {
+  label: string;
+  value: string | number;
+  sub?: string;
+}
+
+function StatCard({ label, value, sub }: StatCardProps) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">{label}</p>
+      <p className="mt-2 text-3xl font-bold text-gray-900 tabular-nums">{value}</p>
+      {sub && <p className="mt-0.5 text-xs text-gray-400">{sub}</p>}
+    </div>
+  );
+}
+
+export default function GovernanceStats({ proposals, votes = [], eligibleCount = 1000 }: GovernanceStatsProps) {
+  const totalProposals = proposals.length;
+  const activeCount = proposals.filter((p) => p.status === 'active').length;
+  const passedCount = proposals.filter((p) => p.status === 'passed' || p.status === 'executed').length;
+  const participationRate = computeParticipationRate(votes, eligibleCount);
+
+  const allVoteWeights = votes.reduce((acc, v) => acc + v.weight, 0);
+  const uniqueVoters = new Set(votes.map((v) => v.voter)).size;
+  const avgWeight = uniqueVoters > 0 ? Math.round(allVoteWeights / uniqueVoters) : 0;
+
+  return (
+    <div className="governance-stats grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <StatCard
+        label="Total Proposals"
+        value={totalProposals}
+        sub={`${activeCount} active · ${passedCount} passed`}
+      />
+      <StatCard
+        label="Participation Rate"
+        value={`${participationRate}%`}
+        sub={`${uniqueVoters} unique voters`}
+      />
+      <StatCard
+        label="Avg Vote Weight"
+        value={avgWeight.toLocaleString()}
+        sub="reputation tokens per voter"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -24,7 +24,7 @@ export default function Navbar() {
             <a href="/review" className="text-sm text-gray-600 hover:text-gray-900">
               Peer Review
             </a>
-            <a href="#governance" className="text-sm text-gray-600 hover:text-gray-900">
+            <a href="/governance" className="text-sm text-gray-600 hover:text-gray-900">
               Governance
             </a>
           </div>

--- a/frontend/src/components/ProposalCard.tsx
+++ b/frontend/src/components/ProposalCard.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { Proposal } from '@/types/governance';
+import { formatBlocksRemaining, getVoteResult } from '@/lib/governanceUtils';
+import ProposalStatusBadge from './ProposalStatusBadge';
+import VoteProgressBar from './VoteProgressBar';
+
+interface ProposalCardProps {
+  proposal: Proposal;
+  currentBlock?: number;
+}
+
+const RESULT_STYLES = {
+  passing: 'text-green-600',
+  failing: 'text-red-600',
+  pending: 'text-gray-400',
+};
+
+export default function ProposalCard({ proposal, currentBlock = 147000 }: ProposalCardProps) {
+  const timeLeft = formatBlocksRemaining(proposal.endBlock, currentBlock);
+  const result = getVoteResult(proposal);
+
+  function truncateAddress(addr: string): string {
+    return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+  }
+
+  return (
+    <article className="proposal-card rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-shadow hover:shadow-md hover:-translate-y-0.5 hover:scale-[1.002] duration-150">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap mb-1">
+            <span className="text-xs text-gray-400 font-mono">#{proposal.id}</span>
+            <ProposalStatusBadge status={proposal.status} />
+          </div>
+          <a
+            href={`/governance/${proposal.id}`}
+            className="group block"
+          >
+            <h3 className="text-base font-semibold text-gray-900 group-hover:text-accent-600 line-clamp-2">
+              {proposal.title}
+            </h3>
+          </a>
+          <p className="mt-1 text-xs text-gray-400">
+            Proposed by {truncateAddress(proposal.proposer)}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2 text-xs shrink-0">
+          {proposal.status === 'active' && (
+            <span className="rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-blue-600 font-medium">
+              {timeLeft}
+            </span>
+          )}
+          {result !== 'pending' && (
+            <span className={`font-semibold capitalize ${RESULT_STYLES[result]}`}>
+              {result}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <VoteProgressBar
+          votesFor={proposal.votesFor}
+          votesAgainst={proposal.votesAgainst}
+          quorum={proposal.quorumRequired}
+        />
+      </div>
+
+      <div className="mt-4 flex items-center justify-end">
+        <a
+          href={`/governance/${proposal.id}`}
+          className="text-xs font-medium text-accent-600 hover:text-accent-700 flex items-center gap-1"
+        >
+          View Details
+          <svg className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
+          </svg>
+        </a>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/components/ProposalCard.tsx
+++ b/frontend/src/components/ProposalCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Proposal } from '@/types/governance';
-import { formatBlocksRemaining, getVoteResult } from '@/lib/governanceUtils';
+import { formatBlocksRemaining, getVoteResult, isQuorumReached } from '@/lib/governanceUtils';
 import ProposalStatusBadge from './ProposalStatusBadge';
 import VoteProgressBar from './VoteProgressBar';
 
@@ -58,6 +58,10 @@ export default function ProposalCard({ proposal, currentBlock = 147000 }: Propos
           )}
         </div>
       </div>
+
+      {isQuorumReached(proposal) && (
+        <p className="mt-2 text-xs text-green-600 font-medium">✓ Quorum reached</p>
+      )}
 
       <div className="mt-4">
         <VoteProgressBar

--- a/frontend/src/components/ProposalForm.tsx
+++ b/frontend/src/components/ProposalForm.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useState } from 'react';
+import { ProposalAction } from '@/types/governance';
+import { useCreateProposal } from '@/hooks/useCreateProposal';
+
+interface ProposalFormProps {
+  onSuccess?: (txId: string) => void;
+}
+
+type ActionType = ProposalAction['type'];
+
+const ACTION_TYPES: { value: ActionType; label: string; description: string }[] = [
+  { value: 'parameter-change', label: 'Parameter Change', description: 'Modify a protocol parameter' },
+  { value: 'contract-upgrade', label: 'Contract Upgrade', description: 'Upgrade a contract to a new version' },
+  { value: 'fund-allocation', label: 'Fund Allocation', description: 'Allocate funds to a recipient' },
+];
+
+interface FieldError {
+  title?: string;
+  description?: string;
+  payload?: string;
+}
+
+export default function ProposalForm({ onSuccess }: ProposalFormProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [actionType, setActionType] = useState<ActionType>('parameter-change');
+  const [paramKey, setParamKey] = useState('');
+  const [paramValue, setParamValue] = useState('');
+  const [contractAddress, setContractAddress] = useState('');
+  const [recipient, setRecipient] = useState('');
+  const [amount, setAmount] = useState('');
+  const [errors, setErrors] = useState<FieldError>({});
+
+  const { createProposal, creating, error: createError, txId } = useCreateProposal();
+
+  function validate(): FieldError {
+    const errs: FieldError = {};
+    if (!title.trim()) errs.title = 'Title is required';
+    if (title.length > 100) errs.title = 'Title must be 100 characters or fewer';
+    if (!description.trim()) errs.description = 'Description is required';
+    if (description.length > 2000) errs.description = 'Description must be 2000 characters or fewer';
+    if (actionType === 'parameter-change' && (!paramKey.trim() || !paramValue.trim())) {
+      errs.payload = 'Both parameter name and value are required';
+    }
+    if (actionType === 'contract-upgrade' && !contractAddress.trim()) {
+      errs.payload = 'Contract address is required';
+    }
+    if (actionType === 'fund-allocation' && (!recipient.trim() || !amount.trim())) {
+      errs.payload = 'Recipient and amount are required';
+    }
+    return errs;
+  }
+
+  function buildPayload(): Record<string, unknown> {
+    if (actionType === 'parameter-change') return { key: paramKey, value: paramValue };
+    if (actionType === 'contract-upgrade') return { contractAddress };
+    if (actionType === 'fund-allocation') return { recipient, amount: Number(amount) };
+    return {};
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const errs = validate();
+    setErrors(errs);
+    if (Object.keys(errs).length > 0) return;
+
+    const tx = await createProposal({
+      title: title.trim(),
+      description: description.trim(),
+      action: { type: actionType, payload: buildPayload() },
+    });
+    if (tx && onSuccess) onSuccess(tx);
+  }
+
+  if (txId) {
+    return (
+      <div className="rounded-xl border border-green-200 bg-green-50 p-6 text-center">
+        <p className="font-semibold text-green-700">Proposal submitted!</p>
+        <a
+          href={`https://explorer.stacks.co/txid/${txId}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-1 block text-sm text-green-600 hover:text-green-700"
+        >
+          View transaction →
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5" noValidate>
+      {/* Title */}
+      <div>
+        <label htmlFor="prop-title" className="block text-sm font-medium text-gray-700 mb-1">
+          Title <span className="text-gray-400 text-xs">({title.length}/100)</span>
+        </label>
+        <input
+          id="prop-title"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          maxLength={100}
+          placeholder="Enter a clear, concise proposal title"
+          className="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-accent-500 focus:outline-none focus:ring-2 focus:ring-accent-500/20"
+        />
+        {errors.title && <p className="mt-1 text-xs text-red-600">{errors.title}</p>}
+      </div>
+
+      {/* Description */}
+      <div>
+        <label htmlFor="prop-desc" className="block text-sm font-medium text-gray-700 mb-1">
+          Description <span className="text-gray-400 text-xs">({description.length}/2000)</span>
+        </label>
+        <textarea
+          id="prop-desc"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          maxLength={2000}
+          rows={5}
+          placeholder="Describe what this proposal changes and why it matters..."
+          className="w-full resize-none rounded-lg border border-gray-200 px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:border-accent-500 focus:outline-none focus:ring-2 focus:ring-accent-500/20"
+        />
+        {errors.description && <p className="mt-1 text-xs text-red-600">{errors.description}</p>}
+      </div>
+
+      {/* Action type */}
+      <div>
+        <label htmlFor="prop-action" className="block text-sm font-medium text-gray-700 mb-1">
+          Action Type
+        </label>
+        <select
+          id="prop-action"
+          value={actionType}
+          onChange={(e) => { setActionType(e.target.value as ActionType); setErrors({}); }}
+          className="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm text-gray-900 focus:border-accent-500 focus:outline-none focus:ring-2 focus:ring-accent-500/20"
+        >
+          {ACTION_TYPES.map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label} — {opt.description}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Dynamic payload fields */}
+      {actionType === 'parameter-change' && (
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label htmlFor="param-key" className="block text-xs font-medium text-gray-600 mb-1">Parameter Name</label>
+            <input id="param-key" type="text" value={paramKey} onChange={(e) => setParamKey(e.target.value)} placeholder="e.g. min-reputation" className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500/20" />
+          </div>
+          <div>
+            <label htmlFor="param-val" className="block text-xs font-medium text-gray-600 mb-1">New Value</label>
+            <input id="param-val" type="text" value={paramValue} onChange={(e) => setParamValue(e.target.value)} placeholder="e.g. 150" className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500/20" />
+          </div>
+        </div>
+      )}
+
+      {actionType === 'contract-upgrade' && (
+        <div>
+          <label htmlFor="upgrade-addr" className="block text-xs font-medium text-gray-600 mb-1">New Contract Address</label>
+          <input id="upgrade-addr" type="text" value={contractAddress} onChange={(e) => setContractAddress(e.target.value)} placeholder="ST..." className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm font-mono focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500/20" />
+        </div>
+      )}
+
+      {actionType === 'fund-allocation' && (
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label htmlFor="fund-recipient" className="block text-xs font-medium text-gray-600 mb-1">Recipient Address</label>
+            <input id="fund-recipient" type="text" value={recipient} onChange={(e) => setRecipient(e.target.value)} placeholder="ST..." className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm font-mono focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500/20" />
+          </div>
+          <div>
+            <label htmlFor="fund-amount" className="block text-xs font-medium text-gray-600 mb-1">Amount (tokens)</label>
+            <input id="fund-amount" type="number" min="1" value={amount} onChange={(e) => setAmount(e.target.value)} placeholder="1000" className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500/20" />
+          </div>
+        </div>
+      )}
+
+      {errors.payload && <p className="text-xs text-red-600">{errors.payload}</p>}
+      {createError && <p className="text-sm text-red-600">{createError}</p>}
+
+      <button
+        type="submit"
+        disabled={creating}
+        className="w-full rounded-lg bg-accent-600 px-4 py-3 text-sm font-semibold text-white shadow-sm hover:bg-accent-700 focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-offset-2 transition disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {creating ? 'Submitting...' : 'Submit Proposal'}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/ProposalStatusBadge.tsx
+++ b/frontend/src/components/ProposalStatusBadge.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { ProposalStatus } from '@/types/governance';
+
+interface ProposalStatusBadgeProps {
+  status: ProposalStatus;
+}
+
+const CONFIG: Record<ProposalStatus, { label: string; classes: string; pulse?: boolean }> = {
+  active: {
+    label: 'Active',
+    classes: 'bg-blue-50 text-blue-700 border-blue-200',
+    pulse: true,
+  },
+  passed: {
+    label: 'Passed',
+    classes: 'bg-green-50 text-green-700 border-green-200',
+  },
+  failed: {
+    label: 'Failed',
+    classes: 'bg-red-50 text-red-700 border-red-200',
+  },
+  pending: {
+    label: 'Pending',
+    classes: 'bg-gray-50 text-gray-600 border-gray-200',
+  },
+  executed: {
+    label: 'Executed',
+    classes: 'bg-purple-50 text-purple-700 border-purple-200',
+  },
+};
+
+export default function ProposalStatusBadge({ status }: ProposalStatusBadgeProps) {
+  const cfg = CONFIG[status];
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium ${cfg.classes}`}
+    >
+      {cfg.pulse ? (
+        <span className="relative flex h-2 w-2" aria-hidden="true">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-400 opacity-75" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-blue-500" />
+        </span>
+      ) : (
+        <span className="h-1.5 w-1.5 rounded-full bg-current opacity-60" aria-hidden="true" />
+      )}
+      {cfg.label}
+    </span>
+  );
+}

--- a/frontend/src/components/ProposalTimeline.tsx
+++ b/frontend/src/components/ProposalTimeline.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { Proposal } from '@/types/governance';
+import { formatBlocksRemaining } from '@/lib/governanceUtils';
+
+interface ProposalTimelineProps {
+  proposal: Proposal;
+  currentBlock?: number;
+}
+
+interface TimelineStep {
+  label: string;
+  block: number;
+  done: boolean;
+  active: boolean;
+}
+
+export default function ProposalTimeline({ proposal, currentBlock = 147000 }: ProposalTimelineProps) {
+  const steps: TimelineStep[] = [
+    {
+      label: 'Created',
+      block: proposal.startBlock - 100,
+      done: true,
+      active: false,
+    },
+    {
+      label: 'Voting Start',
+      block: proposal.startBlock,
+      done: currentBlock >= proposal.startBlock,
+      active: currentBlock >= proposal.startBlock && currentBlock < proposal.endBlock,
+    },
+    {
+      label: 'Voting End',
+      block: proposal.endBlock,
+      done: currentBlock > proposal.endBlock,
+      active: currentBlock === proposal.endBlock,
+    },
+    {
+      label: proposal.executedAt ? 'Executed' : 'Execution',
+      block: proposal.endBlock + 1000,
+      done: !!proposal.executedAt,
+      active: false,
+    },
+  ];
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <h3 className="mb-4 text-sm font-semibold text-gray-700">Timeline</h3>
+      <ol className="relative border-l-2 border-gray-200 ml-3 space-y-6">
+        {steps.map((step, i) => (
+          <li key={i} className="ml-5">
+            <span
+              className={`absolute -left-[11px] flex h-5 w-5 items-center justify-center rounded-full ring-4 ring-white ${
+                step.done ? 'bg-green-500' : step.active ? 'bg-blue-500 animate-pulse' : 'bg-gray-200'
+              }`}
+              aria-hidden="true"
+            />
+            <div>
+              <p className={`text-sm font-medium ${step.done || step.active ? 'text-gray-800' : 'text-gray-400'}`}>
+                {step.label}
+              </p>
+              <p className="text-xs text-gray-400">
+                Block {step.block.toLocaleString()}
+                {step.active && (
+                  <span className="ml-1 text-blue-500">
+                    · {formatBlocksRemaining(step.block, currentBlock)}
+                  </span>
+                )}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/frontend/src/components/QuorumIndicator.tsx
+++ b/frontend/src/components/QuorumIndicator.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { calculateQuorumProgress } from '@/lib/governanceUtils';
+
+interface QuorumIndicatorProps {
+  votes: number;
+  quorum: number;
+  size?: number;
+}
+
+export default function QuorumIndicator({ votes, quorum, size = 80 }: QuorumIndicatorProps) {
+  const pct = calculateQuorumProgress(votes, quorum);
+  const radius = (size - 12) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const strokeDashoffset = circumference - (pct / 100) * circumference;
+
+  let ringColor = '#ef4444'; // red
+  if (pct >= 100) ringColor = '#16a34a'; // green
+  else if (pct >= 50) ringColor = '#eab308'; // yellow
+
+  const center = size / 2;
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        aria-label={`Quorum: ${Math.round(pct)}% of ${quorum.toLocaleString()} votes reached`}
+        role="img"
+      >
+        {/* Track */}
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke="#e5e7eb"
+          strokeWidth={6}
+        />
+        {/* Progress */}
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke={ringColor}
+          strokeWidth={6}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={strokeDashoffset}
+          transform={`rotate(-90 ${center} ${center})`}
+          style={{ transition: 'stroke-dashoffset 0.5s ease' }}
+        />
+        {/* Label */}
+        <text
+          x={center}
+          y={center - 4}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize={size * 0.18}
+          fontWeight="700"
+          fill="#111827"
+        >
+          {Math.round(pct)}%
+        </text>
+        <text
+          x={center}
+          y={center + size * 0.14}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize={size * 0.12}
+          fill="#6b7280"
+        >
+          Quorum
+        </text>
+      </svg>
+      <p className="text-xs text-gray-500 tabular-nums text-center">
+        {votes.toLocaleString()} / {quorum.toLocaleString()}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/VoteButtons.tsx
+++ b/frontend/src/components/VoteButtons.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+interface VoteButtonsProps {
+  proposalId: number;
+  onVote: (proposalId: number, support: boolean) => Promise<void>;
+  hasVoted: boolean;
+  voting: boolean;
+  voteWeight?: number | null;
+}
+
+export default function VoteButtons({ proposalId, onVote, hasVoted, voting, voteWeight }: VoteButtonsProps) {
+  if (hasVoted) {
+    return (
+      <div className="flex items-center justify-center gap-2 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3">
+        <svg className="h-4 w-4 text-green-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+        </svg>
+        <span className="text-sm font-medium text-gray-600">
+          You voted{voteWeight ? ` (weight: ${voteWeight.toLocaleString()})` : ''}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {voteWeight !== undefined && voteWeight !== null && (
+        <p className="text-xs text-gray-500 text-center">
+          Your vote weight: <span className="font-semibold text-gray-700">{voteWeight.toLocaleString()}</span>
+        </p>
+      )}
+      <div className="flex gap-3">
+        <button
+          onClick={() => onVote(proposalId, true)}
+          disabled={voting}
+          aria-label="Vote for this proposal"
+          className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-green-200 bg-green-50 px-4 py-3 text-sm font-semibold text-green-700 shadow-sm transition hover:bg-green-100 hover:border-green-300 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {voting ? (
+            <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+            </svg>
+          ) : (
+            <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+            </svg>
+          )}
+          Vote For
+        </button>
+
+        <button
+          onClick={() => onVote(proposalId, false)}
+          disabled={voting}
+          aria-label="Vote against this proposal"
+          className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700 shadow-sm transition hover:bg-red-100 hover:border-red-300 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {voting ? (
+            <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+            </svg>
+          ) : (
+            <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+            </svg>
+          )}
+          Vote Against
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/VoteHistoryList.tsx
+++ b/frontend/src/components/VoteHistoryList.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Vote } from '@/types/governance';
+
+interface VoteHistoryListProps {
+  votes: Vote[];
+}
+
+function truncateAddress(addr: string): string {
+  return `${addr.slice(0, 8)}...${addr.slice(-4)}`;
+}
+
+export default function VoteHistoryList({ votes }: VoteHistoryListProps) {
+  const sorted = [...votes].sort((a, b) => b.timestamp - a.timestamp);
+
+  return (
+    <div>
+      <h3 className="mb-3 text-sm font-semibold text-gray-700">
+        Vote History ({votes.length} address{votes.length === 1 ? '' : 'es'} voted)
+      </h3>
+
+      {sorted.length === 0 ? (
+        <p className="text-sm text-gray-400 text-center py-4">No votes yet.</p>
+      ) : (
+        <ul className="divide-y divide-gray-100">
+          {sorted.map((vote) => (
+            <li key={vote.txHash} className="flex items-center justify-between py-3 text-sm">
+              <div className="flex items-center gap-3">
+                <div className="h-7 w-7 rounded-full bg-gray-100 flex items-center justify-center text-xs font-bold text-gray-600">
+                  {vote.voter.slice(2, 4).toUpperCase()}
+                </div>
+                <span className="font-mono text-xs text-gray-600">{truncateAddress(vote.voter)}</span>
+              </div>
+
+              <div className="flex items-center gap-3">
+                <span
+                  className={`rounded-full px-2.5 py-0.5 text-xs font-medium border ${
+                    vote.support
+                      ? 'bg-green-50 text-green-700 border-green-200'
+                      : 'bg-red-50 text-red-700 border-red-200'
+                  }`}
+                >
+                  {vote.support ? 'For' : 'Against'}
+                </span>
+                <span className="text-xs text-gray-400 tabular-nums">
+                  {vote.weight.toLocaleString()} pts
+                </span>
+                <span className="text-xs text-gray-300">
+                  {new Date(vote.timestamp).toLocaleDateString()}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/VoteProgressBar.tsx
+++ b/frontend/src/components/VoteProgressBar.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+interface VoteProgressBarProps {
+  votesFor: number;
+  votesAgainst: number;
+  quorum: number;
+}
+
+function formatVotes(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+export default function VoteProgressBar({ votesFor, votesAgainst, quorum }: VoteProgressBarProps) {
+  const total = votesFor + votesAgainst;
+  const forPct = total > 0 ? (votesFor / total) * 100 : 50;
+  const againstPct = total > 0 ? (votesAgainst / total) * 100 : 50;
+  const quorumPct = quorum > 0 ? Math.min(100, (total / quorum) * 100) : 100;
+  const quorumLinePos = quorum > 0 ? Math.min(100, (quorum / (total || quorum)) * 100) : 100;
+
+  return (
+    <div>
+      <div className="flex justify-between text-xs text-gray-500 mb-1">
+        <span className="text-green-600 font-medium">
+          For {formatVotes(votesFor)} ({forPct.toFixed(0)}%)
+        </span>
+        <span className="text-red-600 font-medium">
+          Against {formatVotes(votesAgainst)} ({againstPct.toFixed(0)}%)
+        </span>
+      </div>
+
+      <div className="relative h-3 w-full rounded-full overflow-hidden bg-gray-100">
+        <div
+          className="vote-bar-for absolute left-0 top-0 h-full rounded-l-full transition-all duration-500"
+          style={{ width: `${forPct}%` }}
+          title={`For: ${formatVotes(votesFor)}`}
+        />
+        <div
+          className="vote-bar-against absolute right-0 top-0 h-full rounded-r-full transition-all duration-500"
+          style={{ width: `${againstPct}%` }}
+          title={`Against: ${formatVotes(votesAgainst)}`}
+        />
+        {total > 0 && total < quorum && (
+          <div
+            className="quorum-line absolute top-0 h-full border-l-2 border-dashed border-gray-400 z-10"
+            style={{ left: `${quorumLinePos}%` }}
+            title={`Quorum required: ${formatVotes(quorum)}`}
+          />
+        )}
+      </div>
+
+      <div className="mt-1.5 flex items-center justify-between text-xs text-gray-400">
+        <span>Quorum: {quorumPct.toFixed(0)}%</span>
+        <span>{formatVotes(total)} total votes</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useCreateProposal.ts
+++ b/frontend/src/hooks/useCreateProposal.ts
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import { ProposalAction } from '@/types/governance';
+
+interface CreatePayload {
+  title: string;
+  description: string;
+  action: ProposalAction;
+}
+
+interface UseCreateProposalReturn {
+  creating: boolean;
+  error: string | null;
+  txId: string | null;
+  createProposal: (data: CreatePayload) => Promise<string | null>;
+}
+
+export function useCreateProposal(): UseCreateProposalReturn {
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [txId, setTxId] = useState<string | null>(null);
+
+  async function createProposal(data: CreatePayload): Promise<string | null> {
+    setCreating(true);
+    setError(null);
+
+    try {
+      const { openContractCall } = await import('@stacks/connect');
+      const { stringUtf8CV, stringAsciiCV, tupleCV } = await import('@stacks/transactions');
+
+      const payloadCV = tupleCV(
+        Object.fromEntries(
+          Object.entries(data.action.payload).map(([k, v]) => [
+            k,
+            stringAsciiCV(String(v)),
+          ])
+        )
+      );
+
+      let resolvedTxId: string | null = null;
+
+      await openContractCall({
+        contractAddress: process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ?? 'ST000000000000000000002AMW42H',
+        contractName: 'governance',
+        functionName: 'create-proposal',
+        functionArgs: [
+          stringUtf8CV(data.title),
+          stringUtf8CV(data.description),
+          stringAsciiCV(data.action.type),
+          payloadCV,
+        ],
+        onFinish: ({ txId: id }: { txId: string }) => {
+          resolvedTxId = id;
+          setTxId(id);
+        },
+        onCancel: () => {
+          setError('Transaction cancelled by user.');
+        },
+      });
+
+      return resolvedTxId;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create proposal');
+      return null;
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return { creating, error, txId, createProposal };
+}

--- a/frontend/src/hooks/useFetchProposals.ts
+++ b/frontend/src/hooks/useFetchProposals.ts
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Proposal } from '@/types/governance';
+import { sortProposalsByStatus } from '@/lib/governanceUtils';
+
+// Placeholder proposals — replace with actual Clarity read-only contract calls
+// when the governance contract is deployed.
+const MOCK_PROPOSALS: Proposal[] = [
+  {
+    id: 1,
+    title: 'Increase Minimum Reviewer Reputation Score to 150',
+    description:
+      'This proposal raises the minimum reputation score required to participate as a peer reviewer from 100 to 150. Higher threshold ensures review quality and reduces low-effort submissions.',
+    proposer: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM',
+    status: 'active',
+    votesFor: 8400,
+    votesAgainst: 3200,
+    quorumRequired: 10000,
+    startBlock: 145000,
+    endBlock: 148000,
+    createdAt: 1743500000000,
+  },
+  {
+    id: 2,
+    title: 'Add Reproducibility Criterion to Review Protocol',
+    description:
+      'Amend the review-protocol contract to require reviewers to explicitly evaluate reproducibility as a mandatory criterion with a minimum weight of 10%.',
+    proposer: 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG',
+    status: 'pending',
+    votesFor: 0,
+    votesAgainst: 0,
+    quorumRequired: 10000,
+    startBlock: 149000,
+    endBlock: 152000,
+    createdAt: 1744000000000,
+  },
+  {
+    id: 3,
+    title: 'Allocate 5% of Protocol Revenue to Open Science Fund',
+    description:
+      'Redirect 5% of all protocol fees collected by the publication-registry contract to a community-controlled open science fund for supporting underfunded research projects.',
+    proposer: 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5NH7C3C56',
+    status: 'passed',
+    votesFor: 15800,
+    votesAgainst: 2100,
+    quorumRequired: 10000,
+    startBlock: 140000,
+    endBlock: 143000,
+    createdAt: 1740000000000,
+    executedAt: 1741000000000,
+  },
+];
+
+interface UseFetchProposalsReturn {
+  proposals: Proposal[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useFetchProposals(): UseFetchProposalsReturn {
+  const [proposals, setProposals] = useState<Proposal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      // TODO: replace with callReadOnlyFunction to governance contract
+      await new Promise((res) => setTimeout(res, 400));
+      setProposals(sortProposalsByStatus(MOCK_PROPOSALS));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load proposals');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  return { proposals, loading, error, refetch: fetch };
+}

--- a/frontend/src/hooks/useFetchVotes.ts
+++ b/frontend/src/hooks/useFetchVotes.ts
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Vote } from '@/types/governance';
+
+// In-memory cache keyed by proposalId
+const voteCache = new Map<number, Vote[]>();
+
+const MOCK_VOTES: Vote[] = [
+  {
+    proposalId: 1,
+    voter: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM',
+    support: true,
+    weight: 2500,
+    txHash: '0xabc123',
+    timestamp: 1743600000000,
+  },
+  {
+    proposalId: 1,
+    voter: 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG',
+    support: false,
+    weight: 1800,
+    txHash: '0xdef456',
+    timestamp: 1743650000000,
+  },
+  {
+    proposalId: 3,
+    voter: 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5NH7C3C56',
+    support: true,
+    weight: 3100,
+    txHash: '0xghi789',
+    timestamp: 1740200000000,
+  },
+];
+
+interface UseFetchVotesReturn {
+  votes: Vote[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useFetchVotes(proposalId: number): UseFetchVotesReturn {
+  const [votes, setVotes] = useState<Vote[]>(() => voteCache.get(proposalId) ?? []);
+  const [loading, setLoading] = useState(!voteCache.has(proposalId));
+  const [error, setError] = useState<string | null>(null);
+  const fetchCountRef = useRef(0);
+
+  const fetch = useCallback(async () => {
+    const current = ++fetchCountRef.current;
+    setLoading(true);
+    setError(null);
+
+    try {
+      // TODO: replace with Clarity contract read
+      await new Promise((res) => setTimeout(res, 250));
+      if (current !== fetchCountRef.current) return;
+
+      const data = MOCK_VOTES.filter((v) => v.proposalId === proposalId).sort(
+        (a, b) => b.timestamp - a.timestamp
+      );
+
+      voteCache.set(proposalId, data);
+      setVotes(data);
+    } catch (err) {
+      if (current !== fetchCountRef.current) return;
+      setError(err instanceof Error ? err.message : 'Failed to load votes');
+    } finally {
+      if (current === fetchCountRef.current) setLoading(false);
+    }
+  }, [proposalId]);
+
+  useEffect(() => {
+    if (!voteCache.has(proposalId)) fetch();
+
+    function handleVoteCast(e: Event) {
+      const detail = (e as CustomEvent<{ proposalId: number }>).detail;
+      if (detail.proposalId === proposalId) {
+        voteCache.delete(proposalId);
+        fetch();
+      }
+    }
+
+    window.addEventListener('vote_cast', handleVoteCast);
+    return () => window.removeEventListener('vote_cast', handleVoteCast);
+  }, [proposalId, fetch]);
+
+  return { votes, loading, error, refetch: fetch };
+}

--- a/frontend/src/hooks/useGovernanceStats.ts
+++ b/frontend/src/hooks/useGovernanceStats.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Proposal, Vote } from '@/types/governance';
+import { getProposalSummary, computeParticipationRate } from '@/lib/governanceUtils';
+
+interface GovernanceStatsData {
+  totalProposals: number;
+  activeCount: number;
+  passedCount: number;
+  failedCount: number;
+  pendingCount: number;
+  executedCount: number;
+  participationRate: number;
+  uniqueVoters: number;
+  totalVoteWeight: number;
+  avgVoteWeight: number;
+}
+
+export function useGovernanceStats(
+  proposals: Proposal[],
+  votes: Vote[],
+  eligibleCount = 1000
+): GovernanceStatsData {
+  return useMemo(() => {
+    const summary = getProposalSummary(proposals);
+    const participationRate = computeParticipationRate(votes, eligibleCount);
+    const uniqueVoterSet = new Set(votes.map((v) => v.voter));
+    const uniqueVoters = uniqueVoterSet.size;
+    const totalVoteWeight = votes.reduce((acc, v) => acc + v.weight, 0);
+    const avgVoteWeight = uniqueVoters > 0 ? Math.round(totalVoteWeight / uniqueVoters) : 0;
+
+    return {
+      totalProposals: summary.total,
+      activeCount: summary.active,
+      passedCount: summary.passed,
+      failedCount: summary.failed,
+      pendingCount: summary.pending,
+      executedCount: summary.executed,
+      participationRate,
+      uniqueVoters,
+      totalVoteWeight,
+      avgVoteWeight,
+    };
+  }, [proposals, votes, eligibleCount]);
+}

--- a/frontend/src/hooks/useVote.ts
+++ b/frontend/src/hooks/useVote.ts
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface UseVoteReturn {
+  voting: boolean;
+  error: string | null;
+  txId: string | null;
+  hasVoted: boolean;
+  voteWeight: number | null;
+  vote: (proposalId: number, support: boolean) => Promise<void>;
+}
+
+export function useVote(proposalId: number, address: string | null): UseVoteReturn {
+  const [voting, setVoting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [txId, setTxId] = useState<string | null>(null);
+  const [hasVoted, setHasVoted] = useState(false);
+  const [voteWeight, setVoteWeight] = useState<number | null>(null);
+
+  const localKey = address ? `voted_${proposalId}_${address}` : null;
+
+  // Check localStorage for prior vote
+  useEffect(() => {
+    if (!localKey) return;
+    setHasVoted(!!localStorage.getItem(localKey));
+  }, [localKey]);
+
+  // Fetch vote weight from reputation-token contract
+  useEffect(() => {
+    if (!address) return;
+
+    async function fetchWeight() {
+      try {
+        const { callReadOnlyFunction, standardPrincipalCV, cvToValue } = await import(
+          '@stacks/transactions'
+        );
+        const result = await callReadOnlyFunction({
+          contractAddress: process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ?? 'ST000000000000000000002AMW42H',
+          contractName: 'reputation-token',
+          functionName: 'get-balance',
+          functionArgs: [standardPrincipalCV(address!)],
+          network: 'mainnet' as unknown as Parameters<typeof callReadOnlyFunction>[0]['network'],
+          senderAddress: address!,
+        });
+        const balance = Number(cvToValue(result));
+        setVoteWeight(balance);
+      } catch {
+        setVoteWeight(null);
+      }
+    }
+
+    fetchWeight();
+  }, [address]);
+
+  async function vote(proposalId: number, support: boolean): Promise<void> {
+    if (!address) {
+      setError('Wallet not connected');
+      return;
+    }
+
+    if (hasVoted) {
+      setError('You have already voted on this proposal');
+      return;
+    }
+
+    setVoting(true);
+    setError(null);
+
+    try {
+      const { openContractCall } = await import('@stacks/connect');
+      const { uintCV, boolCV } = await import('@stacks/transactions');
+
+      await openContractCall({
+        contractAddress: process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ?? 'ST000000000000000000002AMW42H',
+        contractName: 'governance',
+        functionName: 'vote',
+        functionArgs: [uintCV(proposalId), boolCV(support)],
+        onFinish: ({ txId: id }: { txId: string }) => {
+          setTxId(id);
+          if (localKey) localStorage.setItem(localKey, id);
+          setHasVoted(true);
+          window.dispatchEvent(new CustomEvent('vote_cast', { detail: { proposalId, support } }));
+        },
+        onCancel: () => {
+          setError('Transaction cancelled');
+        },
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to cast vote');
+    } finally {
+      setVoting(false);
+    }
+  }
+
+  return { voting, error, txId, hasVoted, voteWeight, vote };
+}

--- a/frontend/src/lib/governanceUtils.ts
+++ b/frontend/src/lib/governanceUtils.ts
@@ -1,0 +1,86 @@
+import { Proposal, ProposalStatus, Vote } from '@/types/governance';
+
+export function calculateQuorumProgress(votes: number, quorum: number): number {
+  if (quorum === 0) return 100;
+  return Math.min(100, (votes / quorum) * 100);
+}
+
+export function isQuorumReached(proposal: Proposal): boolean {
+  const totalVotes = proposal.votesFor + proposal.votesAgainst;
+  return totalVotes >= proposal.quorumRequired;
+}
+
+export function getVoteResult(proposal: Proposal): 'passing' | 'failing' | 'pending' {
+  if (!isQuorumReached(proposal)) return 'pending';
+  return proposal.votesFor > proposal.votesAgainst ? 'passing' : 'failing';
+}
+
+const BLOCKS_PER_SECOND = 0.1; // ~10s/block on Stacks
+const SECONDS_PER_DAY = 86400;
+
+export function formatBlocksRemaining(endBlock: number, currentBlock: number): string {
+  const blocksLeft = endBlock - currentBlock;
+  if (blocksLeft <= 0) return 'Ended';
+
+  const secondsLeft = blocksLeft / BLOCKS_PER_SECOND;
+  const daysLeft = Math.floor(secondsLeft / SECONDS_PER_DAY);
+  const hoursLeft = Math.floor((secondsLeft % SECONDS_PER_DAY) / 3600);
+
+  if (daysLeft > 0) return `${daysLeft} day${daysLeft === 1 ? '' : 's'} left`;
+  if (hoursLeft > 0) return `${hoursLeft} hour${hoursLeft === 1 ? '' : 's'} left`;
+  return `${blocksLeft} block${blocksLeft === 1 ? '' : 's'} left`;
+}
+
+export function getProposalStatusColor(status: ProposalStatus): string {
+  const colors: Record<ProposalStatus, string> = {
+    active: 'text-blue-600',
+    passed: 'text-green-600',
+    failed: 'text-red-600',
+    pending: 'text-gray-500',
+    executed: 'text-purple-600',
+  };
+  return colors[status] ?? 'text-gray-500';
+}
+
+export function summarizeVotes(votes: Vote[]): {
+  totalVoters: number;
+  uniqueAddresses: number;
+  forWeight: number;
+  againstWeight: number;
+  turnout: number;
+} {
+  const forWeight = votes.filter((v) => v.support).reduce((acc, v) => acc + v.weight, 0);
+  const againstWeight = votes.filter((v) => !v.support).reduce((acc, v) => acc + v.weight, 0);
+  const uniqueAddresses = new Set(votes.map((v) => v.voter)).size;
+  const totalWeight = forWeight + againstWeight;
+  const turnout = totalWeight > 0 ? Math.round((totalWeight / (totalWeight + 1)) * 100) : 0;
+
+  return {
+    totalVoters: votes.length,
+    uniqueAddresses,
+    forWeight,
+    againstWeight,
+    turnout,
+  };
+}
+
+export function canVote(proposal: Proposal, currentBlock: number): boolean {
+  return (
+    proposal.status === 'active' &&
+    currentBlock >= proposal.startBlock &&
+    currentBlock <= proposal.endBlock
+  );
+}
+
+export function sortProposalsByStatus(proposals: Proposal[]): Proposal[] {
+  const order: ProposalStatus[] = ['active', 'pending', 'passed', 'failed', 'executed'];
+  return [...proposals].sort(
+    (a, b) => order.indexOf(a.status) - order.indexOf(b.status)
+  );
+}
+
+export function computeParticipationRate(votes: Vote[], eligibleCount: number): number {
+  if (eligibleCount === 0) return 0;
+  const unique = new Set(votes.map((v) => v.voter)).size;
+  return Math.round((unique / eligibleCount) * 100);
+}

--- a/frontend/src/lib/governanceUtils.ts
+++ b/frontend/src/lib/governanceUtils.ts
@@ -84,3 +84,44 @@ export function computeParticipationRate(votes: Vote[], eligibleCount: number): 
   const unique = new Set(votes.map((v) => v.voter)).size;
   return Math.round((unique / eligibleCount) * 100);
 }
+
+export function filterProposals(
+  proposals: Proposal[],
+  filter: { status?: ProposalStatus; query?: string }
+): Proposal[] {
+  let result = proposals;
+
+  if (filter.status) {
+    result = result.filter((p) => p.status === filter.status);
+  }
+
+  if (filter.query) {
+    const q = filter.query.toLowerCase();
+    result = result.filter(
+      (p) =>
+        p.title.toLowerCase().includes(q) ||
+        p.description.toLowerCase().includes(q) ||
+        p.proposer.toLowerCase().includes(q)
+    );
+  }
+
+  return result;
+}
+
+export function getProposalSummary(proposals: Proposal[]): {
+  total: number;
+  active: number;
+  passed: number;
+  failed: number;
+  pending: number;
+  executed: number;
+} {
+  return {
+    total: proposals.length,
+    active: proposals.filter((p) => p.status === 'active').length,
+    passed: proposals.filter((p) => p.status === 'passed').length,
+    failed: proposals.filter((p) => p.status === 'failed').length,
+    pending: proposals.filter((p) => p.status === 'pending').length,
+    executed: proposals.filter((p) => p.status === 'executed').length,
+  };
+}

--- a/frontend/src/types/governance.ts
+++ b/frontend/src/types/governance.ts
@@ -1,0 +1,30 @@
+export type ProposalStatus = 'active' | 'passed' | 'failed' | 'pending' | 'executed';
+
+export interface Proposal {
+  id: number;
+  title: string;
+  description: string;
+  proposer: string;
+  status: ProposalStatus;
+  votesFor: number;
+  votesAgainst: number;
+  quorumRequired: number;
+  startBlock: number;
+  endBlock: number;
+  createdAt: number;
+  executedAt?: number;
+}
+
+export interface Vote {
+  proposalId: number;
+  voter: string;
+  support: boolean;
+  weight: number;
+  txHash: string;
+  timestamp: number;
+}
+
+export interface ProposalAction {
+  type: 'parameter-change' | 'contract-upgrade' | 'fund-allocation';
+  payload: Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
- Add Proposal, Vote, ProposalAction and ProposalStatus TypeScript types
- Add governanceUtils with quorum calculation, vote result, block time formatting and participation metrics
- Add useFetchProposals hook with mock data sorted by status (active first)
- Add ProposalCard, VoteProgressBar, ProposalStatusBadge, VoteButtons, QuorumIndicator components
- Add useVote hook calling Clarity governance contract with localStorage deduplication and vote weight fetch from reputation-token
- Add governance hub page (sorted proposals + stats) and proposal detail page with full vote breakdown
- Add ProposalForm with dynamic payload fields (parameter-change, contract-upgrade, fund-allocation)
- Add useCreateProposal, useFetchVotes, useGovernanceStats hooks
- Add VoteHistoryList, GovernanceStats, ProposalTimeline components
- Add governance-specific CSS and governance navigation link